### PR TITLE
ci: publish gnosis.tar.gz reference tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,11 +105,22 @@ jobs:
           path: tests/${{ matrix.preset }}
           merge-multiple: true
 
+      - name: Resolve published preset name
+        id: name
+        run: |
+          # The "mainnet" preset in this fork carries Gnosis values, so publish it as "gnosis".
+          if [ "${{ matrix.preset }}" = "mainnet" ]; then
+            mv tests/mainnet tests/gnosis
+            echo "preset=gnosis" >> "$GITHUB_OUTPUT"
+          else
+            echo "preset=${{ matrix.preset }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Archive reference tests
-        run: tar -czvf ${{ matrix.preset }}.tar.gz tests/${{ matrix.preset }}
+        run: tar -czvf ${{ steps.name.outputs.preset }}.tar.gz tests/${{ steps.name.outputs.preset }}
 
       - name: Upload to release
-        run: gh release upload "${{ needs.setup.outputs.tag }}" ${{ matrix.preset }}.tar.gz
+        run: gh release upload "${{ needs.setup.outputs.tag }}" ${{ steps.name.outputs.preset }}.tar.gz
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,13 +133,24 @@ jobs:
           path: tests/${{ matrix.preset }}
           merge-multiple: true
 
-      - name: Archive reference tests
-        run: tar -czvf ${{ matrix.preset }}.tar.gz tests/${{ matrix.preset }}
+      - name: Resolve published preset name
+        id: name
+        run: |
+          # The "mainnet" preset in this fork carries Gnosis values, so publish it as "gnosis".
+          if [ "${{ matrix.preset }}" = "mainnet" ]; then
+            mv tests/mainnet tests/gnosis
+            echo "preset=gnosis" >> "$GITHUB_OUTPUT"
+          else
+            echo "preset=${{ matrix.preset }}" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Upload ${{ matrix.preset }}.tar.gz
+      - name: Archive reference tests
+        run: tar -czvf ${{ steps.name.outputs.preset }}.tar.gz tests/${{ steps.name.outputs.preset }}
+
+      - name: Upload ${{ steps.name.outputs.preset }}.tar.gz
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          path: ${{ matrix.preset }}.tar.gz
+          path: ${{ steps.name.outputs.preset }}.tar.gz
           archive: false
 
       - name: Delete intermediate artifacts


### PR DESCRIPTION
## What

The `mainnet` preset in this fork carries **Gnosis** values (`SLOTS_PER_EPOCH=16`, `SECONDS_PER_SLOT=5`, `CONFIG_NAME=gnosis`, …), so the reference tests generated for it are really the **Gnosis** test suite. This PR publishes them under a `gnosis` name.

In the `package` jobs of `tests.yml` (nightly artifacts) and `release.yml` (release assets), a new *Resolve published preset name* step renames `tests/mainnet` → `tests/gnosis` for the mainnet matrix entry and produces **`gnosis.tar.gz`**. `general.tar.gz` is unchanged (preset-independent).

## Why

Downstream CL client spec-test harnesses (lighthouse, nimbus, teku, lodestar) route vectors by preset-directory name and run them under their **gnosis** preset. Shipping the suite as `gnosis.tar.gz` (with a top-level `tests/gnosis/`) lets each harness consume it as a normal gnosis preset directory instead of a misleadingly-named `mainnet` one.

This unblocks adding gnosis-preset spec-test CI jobs to the four CL clients.

## Notes

- No change to vector *generation* (`make test … preset=mainnet … reftests=true`); only the published artifact name/layout changes.
- YAML validated; rename logic dry-run tested.